### PR TITLE
Fix: [#239] searchUser 메소드 로직 변경

### DIFF
--- a/src/social/social.module.ts
+++ b/src/social/social.module.ts
@@ -7,11 +7,12 @@ import { SocialResolver } from "./social.resolver";
 import { NotificationService } from "./notification/notification.service";
 import { UserNotification } from "./notification/user.notification.entitiy";
 import { Invite } from "./invite/invite";
+import { User } from "src/user/entity/user.entity";
 
 @Module({
   imports: [
     UserModule,
-    TypeOrmModule.forFeature([Social]),
+    TypeOrmModule.forFeature([Social, User]),
     TypeOrmModule.forFeature([UserNotification]),
   ],
   providers: [SocialService, SocialResolver, NotificationService, Invite],

--- a/src/social/social.service.ts
+++ b/src/social/social.service.ts
@@ -7,7 +7,6 @@ import { Social } from "./entity/social.entity";
 import { Repository } from "typeorm";
 import { NotificationService } from "./notification/notification.service";
 import { FriendDto } from "src/user/dto/friend.dto";
-import { UserMatchTier } from "src/game/utill/game.enum";
 import { User } from "src/user/entity/user.entity";
 import { Invite } from "./invite/invite";
 import { UserNotification } from "./notification/user.notification.entitiy";
@@ -79,13 +78,26 @@ export class SocialService {
     nickname: string,
     page: number
   ): Promise<FriendDto[]> {
-    const searchList: User[] = await this.userService.searchUser(
-      nickname,
-      page
-    );
-    const userTier = UserMatchTier.BRONZE;
+    if (!nickname) {
+      return []; // 빈 닉네임 제공 시, 빈 배열 반환(조회 X)
+    }
+
+    const take = 10;
+    const skip = (page - 1) * take;
+
+    // 유저의 친구 목록
+    const friendList = await this.getFriendList(nickname);
+
+    // 친구 목록에 없고 별명과 일치하는 유저 찾는 옵션
+    const users: User[] = await this.userService.findUserByNickname(nickname);
+    const filteredUsers: User[] = users
+      .filter((user) => !friendList.includes(user.userId))
+      .slice(skip, skip + take);
+
     const userList: FriendDto[] = [];
-    for (const user of searchList) {
+    for (const user of filteredUsers) {
+      const userTier = this.userService.determineUserTier(user.userMmr);
+
       userList.push(
         new FriendDto(
           user.userId,

--- a/src/user/dto/friend.dto.ts
+++ b/src/user/dto/friend.dto.ts
@@ -1,7 +1,6 @@
 import { Field, Int, ObjectType } from "@nestjs/graphql";
 import { userActiveStatus } from "../util/user.enum";
 import { characterEnum } from "../util/character.enum";
-import { UserMatchTier } from "src/game/utill/game.enum";
 
 @ObjectType()
 export class FriendDto {
@@ -11,7 +10,7 @@ export class FriendDto {
     userActive: userActiveStatus,
     character: characterEnum,
     userMmr: number,
-    userTier: UserMatchTier
+    userTier: string
   ) {
     this.userId = userId;
     this.nickname = nickname;
@@ -37,5 +36,5 @@ export class FriendDto {
   character: string;
 
   @Field(() => String)
-  userTier: UserMatchTier;
+  userTier: string;
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -47,6 +47,13 @@ export class UserService {
     return await this.userRepository.findOne({ where: { userId } });
   }
 
+  public async findUserByNickname(nickname: string): Promise<User[]> {
+    return await this.userRepository
+      .createQueryBuilder("user")
+      .where("user.nickname LIKE :nickname", { nickname: `%${nickname}%` })
+      .getMany();
+  }
+
   public async searchUser(nickname: string, page: number): Promise<User[]> {
     const take = 10;
     const skip = (page - 1) * take;


### PR DESCRIPTION
searchUser Query 인자로 nickname, page가 필요합니다.
nickname에 빈 문자열이 입력되면, 아무 유저도 조회하지 않도록 수정했습니다.
특정 유저 검색 시, 본인과 친구가 아닌 유저만 조회될 수 있도록 로직 수정했습니다.